### PR TITLE
Stackdriver Logging: Add stackdriver log format.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,12 @@
 
 
 [[projects]]
+  branch = "master"
+  name = "github.com/TV4/logrus-stackdriver-formatter"
+  packages = ["."]
+  revision = "5feb4e99b2603ed887bcd9e95d77e4115155db03"
+
+[[projects]]
   name = "github.com/bshuster-repo/logrus-logstash-hook"
   packages = ["."]
   revision = "dbc1e22735aa6ed7bd9579a407c17bc7c4a4e046"
@@ -20,9 +26,25 @@
   version = "v1.4.2"
 
 [[projects]]
+  name = "github.com/go-stack/stack"
+  packages = ["."]
+  revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
+  version = "v1.7.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "68e816d1c783414e79bc65b3994d9ab6b0a722ab"
 
 [[projects]]
@@ -69,14 +91,20 @@
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
-  packages = [".","hooks/syslog"]
+  packages = [
+    ".",
+    "hooks/syslog"
+  ]
   revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
   version = "v1.0.3"
 
 [[projects]]
   branch = "master"
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem"
+  ]
   revision = "ee1bd8ee15a1306d1f9201acc41ef39cd9f99a1b"
 
 [[projects]]
@@ -105,7 +133,10 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert","require"]
+  packages = [
+    "assert",
+    "require"
+  ]
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
@@ -118,13 +149,23 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "429f518978ab01db8bb6f44b66785088e7fba58b"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
+  packages = [
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "transform",
+    "unicode/cldr",
+    "unicode/norm"
+  ]
   revision = "1cbadb444a806fd9430d14ad08967ed91da4fa0a"
 
 [[projects]]
@@ -142,6 +183,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ce79896d2d271a301ab497cd504ed37aace820d99b524c62f0c98db22a974947"
+  inputs-digest = "ce770f4b6a12d8f6074938068c980d759d7f6e4b5ff27e062e83b95052b9a787"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ hooks:
   settings: {network: udp, host: localhost, port: 514, tag: MyService, facility: LOG_LOCAL0, severity: LOG_INFO}
 - format: graylog
   settings: {host: graylog.mycompany.io, port: 9000}
+- format: stackdriver
+  settings: {service: myservice, version: v1}
 ```
 
 #### Environment variable config example
@@ -64,7 +66,7 @@ export LOG_LEVEL="info"
 export LOG_FORMAT="logstash"
 export LOG_FORMAT_SETTINGS="type=MyService,ts:RFC3339Nano"
 export LOG_WRITER="stderr"
-export LOG_HOOKS='[{"format":"logstash", "settings":{"type":"MyService","ts":"RFC3339Nano", "network": "udp","host":"logstash.mycompany.io","port": "8911"}},{"format":"syslog","settings":{"network": "udp", "host":"localhost", "port": "514", "tag": "MyService", "facility": "LOG_LOCAL0", "severity": "LOG_INFO"}},{"format":"graylog","settings":{"host":"graylog.mycompany.io","port":"9000"}}]'
+export LOG_HOOKS='[{"format":"logstash", "settings":{"type":"MyService","ts":"RFC3339Nano", "network": "udp","host":"logstash.mycompany.io","port": "8911"}},{"format":"syslog","settings":{"network": "udp", "host":"localhost", "port": "514", "tag": "MyService", "facility": "LOG_LOCAL0", "severity": "LOG_INFO"}},{"format":"graylog","settings":{"host":"graylog.mycompany.io","port":"9000"}},{"format":"stackdriver", "settings":{"service":"myservice","version":"v1"}}]'
 ```
 
 #### Loading and applying configuration
@@ -113,6 +115,9 @@ log:
       settings: {network: udp, host: localhost, port: 514, tag: MyService, facility: LOG_LOCAL0, severity: LOG_INFO}
     - format: graylog
       settings: {host: graylog.mycompany.io, port: 9000}
+    - format: stackdriver
+      settings: {service: myservice, version: v1}
+
 ```
 
 #### Environment variable config example
@@ -123,7 +128,7 @@ export APP_BAR="34"
 export LOG_LEVEL="info"
 export LOG_FORMAT="json"
 export LOG_WRITER="stderr"
-export LOG_HOOKS='[{"format":"logstash", "settings":{"type":"MyService","ts":"RFC3339Nano", "network": "udp","host":"logstash.mycompany.io","port": "8911"}},{"format":"syslog","settings":{"network": "udp", "host":"localhost", "port": "514", "tag": "MyService", "facility": "LOG_LOCAL0", "severity": "LOG_INFO"}},{"format":"graylog","settings":{"host":"graylog.mycompany.io","port":"9000"}}]'
+export LOG_HOOKS='[{"format":"logstash", "settings":{"type":"MyService","ts":"RFC3339Nano", "network": "udp","host":"logstash.mycompany.io","port": "8911"}},{"format":"syslog","settings":{"network": "udp", "host":"localhost", "port": "514", "tag": "MyService", "facility": "LOG_LOCAL0", "severity": "LOG_INFO"}},{"format":"graylog","settings":{"host":"graylog.mycompany.io","port":"9000"}},{"format":"stackdriver", "settings":{"service":"myservice","version":"v1"}}]'
 ```
 
 #### Loading and applying configuration
@@ -226,6 +231,18 @@ Uses [`github.com/gemnasium/logrus-graylog-hook` implementation](https://github.
 | `host`  | **YES**  | Graylog host name or IP address                                                                                                                      |
 | `port`  | **YES**  | Graylog host port                                                                                                                                    |
 | `async` | no       | send log messages to Graylog in synchronous or asynchronous mode, string value must be [parsable to bool](https://golang.org/pkg/strconv/#ParseBool) |
+
+### `Stackdriver`
+
+Stackdriver formatter for Google Cloud Container Engine(GKE/Kubernetes).
+
+Uses [`github.com/TV4/logrus-stackdriver-formatter` implementation](https://github.com/TV4/logrus-stackdriver-formatter)
+
+| Setting   | Required | Description                                    |
+|-----------|----------|------------------------------------------------|
+| `service` | no       | Optional Service Name referring to this logger |
+| `version` | no       | Optional Service version                       |
+
 
 
 ## Contributing

--- a/assets/config.yml
+++ b/assets/config.yml
@@ -11,3 +11,5 @@ hooks:
   settings: {network: udp, host: localhost, port: 514, tag: MyService, facility: LOG_LOCAL0, severity: LOG_INFO}
 - format: graylog
   settings: {host: graylog.mycompany.io, port: 9000}
+- format: stackdriver
+  settings: {service: myservice, version: v1}

--- a/log_config.go
+++ b/log_config.go
@@ -138,7 +138,7 @@ func (c LogConfig) getFormatter() log.Formatter {
 	case Logstash:
 		return getLogstashFormatter(c.FormatSettings)
 	case Stackdriver:
-		return &stackdriver.Formatter{}
+		return getStackdriverFormatter(c.FormatSettings)
 	case Text:
 		fallthrough
 	default:
@@ -166,6 +166,22 @@ func getLogstashFormatter(settings map[string]string) log.Formatter {
 	tsFormat, _ := tsFormats[logstashTSFormat]
 
 	return &logrustash.LogstashFormatter{Type: logstashType, TimestampFormat: tsFormat}
+}
+
+func getStackdriverFormatter(settings map[string]string) log.Formatter {
+	options := []stackdriver.Option{}
+
+	service, ok := settings["service"]
+	if ok {
+		options = append(options, stackdriver.WithService(service))
+	}
+
+	version, ok := settings["version"]
+	if ok {
+		options = append(options, stackdriver.WithVersion(version))
+	}
+
+	return stackdriver.NewFormatter(options...)
 }
 
 // InitDefaults initialises default logger settings

--- a/log_config.go
+++ b/log_config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	stackdriver "github.com/TV4/logrus-stackdriver-formatter"
 	"github.com/bshuster-repo/logrus-logstash-hook"
 	"github.com/kelseyhightower/envconfig"
 	log "github.com/sirupsen/logrus"
@@ -38,6 +39,8 @@ const (
 	JSON LogFormat = "json"
 	// Logstash is json log format with some additional fields required for logstash
 	Logstash LogFormat = "logstash"
+	// Stackdriver is Google cloud FluentD Stackdriver format
+	Stackdriver LogFormat = "stackdriver"
 
 	// StdErr is os stderr log writer
 	StdErr LogWriter = "stderr"
@@ -134,6 +137,8 @@ func (c LogConfig) getFormatter() log.Formatter {
 		return &log.JSONFormatter{}
 	case Logstash:
 		return getLogstashFormatter(c.FormatSettings)
+	case Stackdriver:
+		return &stackdriver.Formatter{}
 	case Text:
 		fallthrough
 	default:


### PR DESCRIPTION
Stackdriver relies on the **Severity** field to correctly set the log levels.  As a result, all logs that do not include **severity** are considered errors cluttering all the logs and making it impossible to distinguish different log levels. 

The next screenshot shows an example of the issue.

![screen shot 2018-02-23 at 15 18 49](https://user-images.githubusercontent.com/168180/36601381-e7665f8a-18ac-11e8-8bf8-218b96f6f6e6.png)


This PR adds Google Cloud Stackdriver logging format.

![](https://3.bp.blogspot.com/-np2BgLqJUJg/WaRXv_IRetI/AAAAAAAAEVc/zwrc3X8xI8oKrKIGumADkriR2fFCXklpACLcBGAs/s1600/google-cloud-diagnostics-3.png)

